### PR TITLE
fix: clickhouse internal setup

### DIFF
--- a/charts/portkey-app/values.yaml
+++ b/charts/portkey-app/values.yaml
@@ -636,7 +636,9 @@ clickhouse:
     nodeSelector: {}
     tolerations: []
     affinity: {}
-    volumes: []
+    volumes:
+      - name: data
+        emptyDir: {}
     # We recommend using a persistent volume and increasing the storage size to something like 50Gi when using in a production environment!
     persistence:
       enabled: false


### PR DESCRIPTION
use default volume to run migrations