### PR TITLE
add helm chart release workflow for Portkey Full Deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chart_releaser
     paths:
       - 'charts/**'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
       - chart_releaser
     paths:
       - 'charts/**'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.12.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'charts/**'
+      - 'charts/portkey-app/Chart.yaml'
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-      - chart_releaser
     paths:
       - 'charts/**'
-  workflow_dispatch:
 
 jobs:
   release:

--- a/charts/portkey-app/docs/installation.md
+++ b/charts/portkey-app/docs/installation.md
@@ -11,7 +11,7 @@ This guide will walk you through the process of deploying Portkey to your Kubern
 4. A configured values.yaml file (see [Configuration Guide](./configuration.md))
 5. A sample config file is provided [here](./sample-config.yaml)
 
-### Step 1: Prepare Your Kubernetes Environment
+### Prepare Your Kubernetes Environment
 
 First, ensure you have access to your Kubernetes cluster:
 
@@ -19,49 +19,43 @@ First, ensure you have access to your Kubernetes cluster:
 kubectl get nodes
 ```
 
+## Install Chart 
 If this command returns a list of nodes, you're good to go. If not, check your Kubernetes configuration.
 
-### Step 2: Get the Portkey Helm Chart
+1. Add the helm repo 
+   ```bash
+   helm repo add portkey-ai https://portkeyai.github.io/portkey-app
+   ```
 
-Pull the Portkey Helm repository
+2. Update the helm repo 
+   ```bash
+   helm repo update
+   ```
 
-```bash
-git clone https://github.com/Portkey-AI/helm.git portkey-helm
-cd portkey-helm
-```
+3. Install the chart 
+   ```bash
+   helm upgrade --install portkey-ai portkey-ai/portkey-app -f ./chart/values.yaml -n portkeyai --create-namespace
+   ```
 
-### Step 3: Install Portkey
-
-Now, let's deploy Portkey using Helm:
-
-```bash
-helm install portkey ./charts/portkey-app --values /path/to/values.yaml --namespace portkey --create-namespace
-```
-
-Replace `<your-namespace>` with your desired namespace
+4. Check the deployment 
+   ```bash
+   kubectl get pods -n portkeyai
+   ```
 
 This command will:
 - Create the specified namespace if it doesn't exist
 - Install Portkey with the configurations from `values.yaml`
 - Wait for all resources to be ready before completing
 
-### Step 4: Verify the Deployment
-
-After installation, verify that all Portkey components are running:
-
-```bash
-kubectl get pods -n <your-namespace>
-```
-
 You should see pods for components like backend, frontend, gateway, and databases (MySQL, Redis, ClickHouse) in a "Running" state.
 
-### Step 5: Access Portkey Services
+## Access Portkey Services
 
 To access Portkey services:
 
 1. List the services:
    ```bash
-   kubectl get services -n <your-namespace>
+   kubectl get services -n portkeyai
    ```
 
 2. Note the EXTERNAL-IP for the `portkey-frontend` service. This is your entry point to the Portkey UI.
@@ -80,12 +74,12 @@ If you encounter issues:
 
 1. Check pod status:
    ```bash
-   kubectl describe pods -n <your-namespace>
+   kubectl describe pods -n portkeyai
    ```
 
 2. View logs for a specific pod:
    ```bash
-   kubectl logs <pod-name> -n <your-namespace>
+   kubectl logs <pod-name> -n portkeyai
    ```
 
 3. Ensure all config values in `portkey_config.yaml` are correct for your environment.


### PR DESCRIPTION
## Working
1. On `main` branch push, workflow runs that builds a helm package
2. Pushes as a release with version
3. Pushes the updated chart `index.yaml` file in `gh-pages` branch.

## Usage
1. Add the helm repo `helm repo add portkey-ai https://portkeyai.github.io/portkey-app`

2. Update the helm repo `helm repo update`

3. Install the chart `helm upgrade --install portkey-ai portkey-ai/portkey-app -f ./chart/values.yaml -n portkeyai --create-namespace`