### PR TITLE
add behaviour for HPA to scale up gateway pods quickly at scale

### DIFF
--- a/charts/portkey-app/templates/gateway/hpa.yaml
+++ b/charts/portkey-app/templates/gateway/hpa.yaml
@@ -29,4 +29,20 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.gateway.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default 0 }}
+      policies:
+      - type: Pods
+        value: {{ .Values.gateway.autoscaling.behavior.scaleUp.podScaleUpValue | default 4 }}
+        periodSeconds: {{ .Values.gateway.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+      - type: Percent
+        value: {{ .Values.gateway.autoscaling.behavior.scaleUp.percentScaleUpValue | default 100 }}
+        periodSeconds: {{ .Values.gateway.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.gateway.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default 300 }}
+      policies:
+      - type: Pods
+        value: {{ .Values.gateway.autoscaling.behavior.scaleDown.podScaleDownValue | default 1 }}
+        periodSeconds: {{ .Values.gateway.autoscaling.behavior.scaleDown.periodSeconds | default 60 }}
 {{- end }}

--- a/charts/portkey-app/values.yaml
+++ b/charts/portkey-app/values.yaml
@@ -243,7 +243,7 @@ gateway:
       httpGet:
         path: /v1/health
         port: 8787
-      initialDelaySeconds: 60
+      initialDelaySeconds: 5
       failureThreshold: 3
       periodSeconds: 10
       timeoutSeconds: 1
@@ -284,10 +284,20 @@ gateway:
   autoscaling:
     enabled: false
     createHpa: false
-    minReplicas: 1
-    maxReplicas: 5
-    targetCPUUtilizationPercentage: 80
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        podScaleUpValue: 2
+        percentScaleUpValue: 100
+        periodSeconds: 2
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        podScaleDownValue: 1
+        periodSeconds: 60
     
 dataservice:
   name: "dataservice"

--- a/charts/portkey-app/values.yaml
+++ b/charts/portkey-app/values.yaml
@@ -243,7 +243,7 @@ gateway:
       httpGet:
         path: /v1/health
         port: 8787
-      initialDelaySeconds: 5
+      initialDelaySeconds: 3
       failureThreshold: 3
       periodSeconds: 10
       timeoutSeconds: 1
@@ -282,8 +282,8 @@ gateway:
     labels: {}
     annotations: {}
   autoscaling:
-    enabled: false
-    createHpa: false
+    enabled: true
+    createHpa: true
     minReplicas: 2
     maxReplicas: 20
     targetCPUUtilizationPercentage: 60

--- a/charts/portkey-gateway/templates/gateway/hpa.yaml
+++ b/charts/portkey-gateway/templates/gateway/hpa.yaml
@@ -29,4 +29,20 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default 0 }}
+      policies:
+      - type: Pods
+        value: {{ .Values.autoscaling.behavior.scaleUp.podScaleUpValue | default 4 }}
+        periodSeconds: {{ .Values.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+      - type: Percent
+        value: {{ .Values.autoscaling.behavior.scaleUp.percentScaleUpValue | default 100 }}
+        periodSeconds: {{ .Values.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default 300 }}
+      policies:
+      - type: Pods
+        value: {{ .Values.autoscaling.behavior.scaleDown.podScaleDownValue | default 1 }}
+        periodSeconds: {{ .Values.autoscaling.behavior.scaleDown.periodSeconds | default 60 }}
 {{- end }}

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -135,26 +135,36 @@ livenessProbe:
   httpGet:
     path: /v1/health
     port: 8787
-  initialDelaySeconds: 30
+  initialDelaySeconds: 5
   periodSeconds: 60
-  timeoutSeconds: 5
-  failureThreshold: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
 readinessProbe:
   httpGet:
     path: /v1/health
     port: 8787
-  initialDelaySeconds: 30
+  initialDelaySeconds: 5
   periodSeconds: 60
-  timeoutSeconds: 5
+  timeoutSeconds: 3
   successThreshold: 1
-  failureThreshold: 5
+  failureThreshold: 3
 
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+  minReplicas: 2
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 60
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      podScaleUpValue: 2
+      percentScaleUpValue: 100
+      periodSeconds: 2
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      podScaleDownValue: 1
+      periodSeconds: 60
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
## 🚀 What Changed  
- Added HPA (Horizontal Pod Autoscaler) behavior configuration to scale up gateway pods quickly  
- Modified HPA templates in both portkey-app and portkey-gateway charts  
- Adjusted autoscaling parameters for faster scale-up and controlled scale-down  
- Reduced initialDelaySeconds for liveness and readiness probes from 60/30 to 5 seconds  

## 🔄 Impact of the Change  
- Gateway pods will scale up more rapidly during high load (2 pods every 2 seconds)  
- Scale down is more conservative (1 pod every 60 seconds with 300s stabilization window)  
- Faster pod readiness detection with reduced probe delays  
- Default min replicas increased from 1 to 2 for better availability  

## 📁 Total Files Changed  
- 4 files modified with 66 additions and 14 deletions  

## 🧪 Test Added  
- No explicit tests added in this PR