### PR TITLE
feat: add redis.deployLocal toggle and HPA enhancements

### DIFF
--- a/charts/portkey-gateway/templates/gateway/hpa.yaml
+++ b/charts/portkey-gateway/templates/gateway/hpa.yaml
@@ -29,9 +29,19 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default 0 }}
+      {{- if .Values.autoscaling.behavior.scaleUp.selectPolicy }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleUp.selectPolicy }}
+      {{- end }}
+      {{- if .Values.autoscaling.behavior.scaleUp.policies }}
+      policies:
+        {{- toYaml .Values.autoscaling.behavior.scaleUp.policies | nindent 8 }}
+      {{- else }}
       policies:
       - type: Pods
         value: {{ .Values.autoscaling.behavior.scaleUp.podScaleUpValue | default 4 }}
@@ -39,10 +49,19 @@ spec:
       - type: Percent
         value: {{ .Values.autoscaling.behavior.scaleUp.percentScaleUpValue | default 100 }}
         periodSeconds: {{ .Values.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+      {{- end }}
     scaleDown:
       stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default 300 }}
+      {{- if .Values.autoscaling.behavior.scaleDown.selectPolicy }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleDown.selectPolicy }}
+      {{- end }}
+      {{- if .Values.autoscaling.behavior.scaleDown.policies }}
+      policies:
+        {{- toYaml .Values.autoscaling.behavior.scaleDown.policies | nindent 8 }}
+      {{- else }}
       policies:
       - type: Pods
         value: {{ .Values.autoscaling.behavior.scaleDown.podScaleDownValue | default 1 }}
         periodSeconds: {{ .Values.autoscaling.behavior.scaleDown.periodSeconds | default 60 }}
+      {{- end }}
 {{- end }}

--- a/charts/portkey-gateway/templates/redis/deployment.yaml
+++ b/charts/portkey-gateway/templates/redis/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.environment.data.CACHE_STORE "redis" }}
+{{- if and (eq .Values.environment.data.CACHE_STORE "redis") (ne (.Values.redis.deployLocal | toString) "false") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/portkey-gateway/templates/redis/deployment.yaml
+++ b/charts/portkey-gateway/templates/redis/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.environment.data.CACHE_STORE "redis") (ne (.Values.redis.deployLocal | toString) "false") }}
+{{- if and (eq .Values.environment.data.CACHE_STORE "redis") .Values.redis.deployLocal }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/portkey-gateway/templates/redis/service.yaml
+++ b/charts/portkey-gateway/templates/redis/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.environment.data.CACHE_STORE "redis") (ne (.Values.redis.deployLocal | toString) "false") }}
+{{- if and (eq .Values.environment.data.CACHE_STORE "redis") .Values.redis.deployLocal }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/portkey-gateway/templates/redis/service.yaml
+++ b/charts/portkey-gateway/templates/redis/service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.environment.data.CACHE_STORE "redis" }}
+{{- if and (eq .Values.environment.data.CACHE_STORE "redis") (ne (.Values.redis.deployLocal | toString) "false") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -248,8 +248,8 @@ autoscaling:
       periodSeconds: 2
       # policies:
       # - type: Pods
-      #   value: 4
-      #   periodSeconds: 15
+      #   value: 2
+      #   periodSeconds: 2
     scaleDown:
       stabilizationWindowSeconds: 300
       # selectPolicy: Min

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -416,7 +416,10 @@ redis:
   servicePort: 6379
   containerPort: 6379
   resources: {}
-  # Set to false to skip in-cluster Redis when using external Redis/ElastiCache
+  # Set to false to skip deploying in-cluster Redis when using an external Redis/ElastiCache instance.
+  # When deployLocal is set to false, you MUST also configure Redis connection env vars
+  # (e.g. environment.data.REDIS_URL, or REDIS_HOST/REDIS_PORT) to point to your external Redis;
+  # otherwise the deployment will still try to connect to the default in-cluster service (redis://redis:6379).
   deployLocal: true
 
 # MinIO configuration section

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -238,16 +238,27 @@ autoscaling:
   maxReplicas: 20
   targetCPUUtilizationPercentage: 60
   targetMemoryUtilizationPercentage: 60
+  # customMetrics: []
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0
+      # selectPolicy: Max
       podScaleUpValue: 2
       percentScaleUpValue: 100
       periodSeconds: 2
+      # policies:
+      # - type: Pods
+      #   value: 4
+      #   periodSeconds: 15
     scaleDown:
       stabilizationWindowSeconds: 300
+      # selectPolicy: Min
       podScaleDownValue: 1
       periodSeconds: 60
+      # policies:
+      # - type: Pods
+      #   value: 1
+      #   periodSeconds: 60
 
 # Additional volumes on the output Deployment definition.
 volumes: []
@@ -400,11 +411,13 @@ dataservice:
 
 # Redis-specific configuration section
 redis:
-  name: "redis"  
-  serviceType: NodePort  
+  name: "redis"
+  serviceType: NodePort
   servicePort: 6379
   containerPort: 6379
   resources: {}
+  # Set to false to skip in-cluster Redis when using external Redis/ElastiCache
+  deployLocal: true
 
 # MinIO configuration section
 minio:


### PR DESCRIPTION
**redis.deployLocal** (default: `true`): Set to `false` to skip in-cluster Redis Deployment and Service when using external Redis (ElastiCache, Azure Cache, etc.). Uses bare truthiness consistent with every other boolean guard in the chart (`dataservice.enabled`, `autoscaling.enabled`, etc.).

When disabling local Redis, set `REDIS_URL` in `environment.data` to point at the external instance.

**HPA enhancements:**
- `customMetrics`: inject arbitrary HPA metric types alongside CPU/memory
- `selectPolicy`: configure Max/Min/Disabled for scaleUp/scaleDown
- `policies`: override default Pods+Percent policies with a custom list

All backward-compatible with existing defaults.

See also #173 which adds CI to validate chart templates on PRs.