### PR TITLE
feat(hpa): add customMetrics, selectPolicy, and configurable policies

### DIFF
--- a/charts/portkey-gateway/templates/gateway/hpa.yaml
+++ b/charts/portkey-gateway/templates/gateway/hpa.yaml
@@ -29,9 +29,19 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default 0 }}
+      {{- if .Values.autoscaling.behavior.scaleUp.selectPolicy }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleUp.selectPolicy }}
+      {{- end }}
+      {{- if .Values.autoscaling.behavior.scaleUp.policies }}
+      policies:
+        {{- toYaml .Values.autoscaling.behavior.scaleUp.policies | nindent 8 }}
+      {{- else }}
       policies:
       - type: Pods
         value: {{ .Values.autoscaling.behavior.scaleUp.podScaleUpValue | default 4 }}
@@ -39,10 +49,19 @@ spec:
       - type: Percent
         value: {{ .Values.autoscaling.behavior.scaleUp.percentScaleUpValue | default 100 }}
         periodSeconds: {{ .Values.autoscaling.behavior.scaleUp.periodSeconds | default 15 }}
+      {{- end }}
     scaleDown:
       stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default 300 }}
+      {{- if .Values.autoscaling.behavior.scaleDown.selectPolicy }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleDown.selectPolicy }}
+      {{- end }}
+      {{- if .Values.autoscaling.behavior.scaleDown.policies }}
+      policies:
+        {{- toYaml .Values.autoscaling.behavior.scaleDown.policies | nindent 8 }}
+      {{- else }}
       policies:
       - type: Pods
         value: {{ .Values.autoscaling.behavior.scaleDown.podScaleDownValue | default 1 }}
         periodSeconds: {{ .Values.autoscaling.behavior.scaleDown.periodSeconds | default 60 }}
+      {{- end }}
 {{- end }}

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -238,16 +238,27 @@ autoscaling:
   maxReplicas: 20
   targetCPUUtilizationPercentage: 60
   targetMemoryUtilizationPercentage: 60
+  # customMetrics: []
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0
+      # selectPolicy: Max
       podScaleUpValue: 2
       percentScaleUpValue: 100
       periodSeconds: 2
+      # policies:
+      # - type: Pods
+      #   value: 2
+      #   periodSeconds: 2
     scaleDown:
       stabilizationWindowSeconds: 300
+      # selectPolicy: Min
       podScaleDownValue: 1
       periodSeconds: 60
+      # policies:
+      # - type: Pods
+      #   value: 1
+      #   periodSeconds: 60
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
Split from #172 per @sk-portkey's feedback — HPA enhancements only, redis.deployLocal removed.

- Support `autoscaling.customMetrics` for injecting arbitrary HPA metrics
- Add `selectPolicy` (Max/Min/Disabled) for scaleUp and scaleDown behavior
- Allow full `policies` override per direction; existing defaults preserved when not specified

Validated with `helm lint` and `helm template` (default values + custom overrides).