### PR TITLE
chore: bump version to 1.7.5 for portkey-app and portkey-gateway

### DIFF
--- a/charts/portkey-app/Chart.yaml
+++ b/charts/portkey-app/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart to deploy the Portkey Full Stack application and all dep
 home: https://portkey.ai/
 icon: https://avatars.githubusercontent.com/u/131141116?s=200&v=4
 type: application
-version: 1.7.4
+version: 1.7.5
 appVersion: "1.17.0"
 maintainers:
   - name: Ayush

--- a/charts/portkey-gateway/Chart.yaml
+++ b/charts/portkey-gateway/Chart.yaml
@@ -4,8 +4,8 @@ description: Helm chart to deploy the Portkey AI Gateway application in a hybrid
 home: https://portkey.ai/
 icon: https://avatars.githubusercontent.com/u/131141116?s=200&v=4
 type: application
-version: "1.7.4"
-appVersion: "2.7.1"
+version: "1.7.5"
+appVersion: "2.9.0"
 maintainers:
   - name: Ayush
     email: ayush@portkey.ai

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -17,11 +17,11 @@ images:
   gatewayImage:
     repository: "docker.io/portkeyai/gateway_enterprise"
     pullPolicy: IfNotPresent
-    tag: "2.7.1"
+    tag: "2.9.0"
   dataserviceImage:
     repository: "docker.io/portkeyai/data-service"
     pullPolicy: IfNotPresent
-    tag: "1.7.0"
+    tag: "1.8.0"
   # Add Redis image configuration
   redisImage:
     repository: "docker.io/redis"


### PR DESCRIPTION
Updated the version and appVersion for both portkey-app and portkey-gateway charts to 1.7.5 and 2.9.0 respectively. Also updated the image tags for the gateway and dataservice images to 2.9.0 and 1.8.0.