### PR TITLE
fix: disable noAuth by default in configuration files

### DIFF
--- a/charts/portkey-app/config-samples/openshift.yaml
+++ b/charts/portkey-app/config-samples/openshift.yaml
@@ -29,7 +29,7 @@ config:
   disableOrgCreation: false # Set to true to disable organization creation post installation and first time login
   disableTestimonial: true # Set to true to disable testimonial section in the frontend
   noAuth:
-    enabled: true # Set to true to disable authentication and allow access to the application without any authentication
+    enabled: false # Set to true to disable authentication and allow access to the application without any authentication
   controlPlaneURL: "<frontend-lb-endpoint>" # Set to the control plane URL of the frontend lb  
 
 logStorage:

--- a/charts/portkey-app/docs/configuration.md
+++ b/charts/portkey-app/docs/configuration.md
@@ -30,11 +30,11 @@ config:
   logStore: "s3"
   jwtPrivateKey: ""   # Required: set a strong secret, or provide it via config.existingSecretName
   noAuth:
-    enabled: true
+    enabled: false
 ```
 -  Set the log store as s3
 - JWT Private Key is required for session management. The chart fails to render if `config.jwtPrivateKey` is empty and `config.existingSecretName` is not set, so set a strong secret (or provide it via `config.existingSecretName`).
-- If you are installing for the first time you should set noAuth.enabled true. This will allow you to access the application without any authentication, post which you can configure OAuth and switch it on.
+- If you are installing for the first time you should set noAuth.enabled true. This will allow you to access the application without any authentication, post which you should configure OAuth and switch it on.
 - Strongly recommended to use OAuth for authentication in production.
 
 ### Blob Storage Configuration

--- a/charts/portkey-app/docs/sample-config.yaml
+++ b/charts/portkey-app/docs/sample-config.yaml
@@ -9,7 +9,7 @@ imagePullSecrets: [portkeyenterpriseregistrycredentials]
 config:
   jwtPrivateKey: ""   # Required: set a strong secret for signing frontend JWT tokens, or provide it via config.existingSecretName
   noAuth:
-    enabled: true
+    enabled: false
 
 logStorage:
   logStore: "s3"


### PR DESCRIPTION
Updated the noAuth.enabled setting from true to false in openshift.yaml, configuration.md, and sample-config.yaml to enhance security by requiring authentication by default. This change ensures that users must configure OAuth for access after installation.