### PR TITLE
feat: add revisionHistoryLimit to deployments and stateful sets in po…

### DIFF
--- a/charts/portkey-app/templates/backend/deployment.yaml
+++ b/charts/portkey-app/templates/backend/deployment.yaml
@@ -13,6 +13,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.backend.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.backend.deployment.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.backend.deployment.replicas }}
   {{- end }}

--- a/charts/portkey-app/templates/clickhouse/stateful-set.yaml
+++ b/charts/portkey-app/templates/clickhouse/stateful-set.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.clickhouse.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.clickhouse.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: {{ include "portkey.fullname" . }}-{{ .Values.clickhouse.name }}
   replicas: {{ .Values.clickhouse.statefulSet.replicas | default 1 }}
   selector:

--- a/charts/portkey-app/templates/dataservice/deployment.yaml
+++ b/charts/portkey-app/templates/dataservice/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.dataservice.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.dataservice.deployment.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.dataservice.autoscaling.enabled }}
   replicas: {{ .Values.dataservice.deployment.replicas }}
   {{- end }}

--- a/charts/portkey-app/templates/frontend/deployment.yaml
+++ b/charts/portkey-app/templates/frontend/deployment.yaml
@@ -13,6 +13,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.frontend.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.frontend.deployment.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.frontend.autoscaling.enabled }}
   replicas: {{ .Values.frontend.deployment.replicas }}
   {{- end }}

--- a/charts/portkey-app/templates/gateway/deployment.yaml
+++ b/charts/portkey-app/templates/gateway/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.gateway.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.gateway.deployment.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.gateway.autoscaling.enabled }}
   replicas: {{ .Values.gateway.deployment.replicas }}
   {{- end }}

--- a/charts/portkey-app/templates/mysql/stateful-set.yaml
+++ b/charts/portkey-app/templates/mysql/stateful-set.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.mysql.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.mysql.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: {{ include "portkey.fullname" . }}-{{ .Values.mysql.name }}
   replicas: {{ .Values.mysql.statefulSet.replicas | default 1 }}
   selector:

--- a/charts/portkey-app/templates/redis/stateful-set.yaml
+++ b/charts/portkey-app/templates/redis/stateful-set.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.redis.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.redis.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: {{ include "portkey.fullname" . }}-{{ .Values.redis.name }}
   replicas: {{ .Values.redis.statefulSet.replicas | default 1 }}
   selector:

--- a/charts/portkey-app/values.yaml
+++ b/charts/portkey-app/values.yaml
@@ -176,6 +176,8 @@ backend:
   deployment:
     autoRestart: true
     replicas: 1
+    # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -276,6 +278,8 @@ gateway:
   deployment:
     autoRestart: true
     replicas: 1
+    # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -377,6 +381,8 @@ dataservice:
   deployment:
     autoRestart: true
     replicas: 1
+    # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -475,6 +481,8 @@ frontend:
   deployment:
     autoRestart: true
     replicas: 1
+    # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -596,6 +604,8 @@ mysql:
     podSecurityContext: {}
     securityContext: {}
     replicas: 1
+    # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     # resources:
     #   limits:
     #     cpu: 2000m
@@ -693,6 +703,8 @@ redis:
     podSecurityContext: {}
     securityContext: {}
     replicas: 1
+    # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     # resources:
     #   limits:
     #     cpu: 4000m
@@ -830,6 +842,8 @@ clickhouse:
     podSecurityContext: {}
     securityContext: {}
     replicas: 1
+    # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     # resources:
     #   limits:
     #     cpu: 1000m

--- a/charts/portkey-gateway/templates/dataservice/deployment.yaml
+++ b/charts/portkey-gateway/templates/dataservice/deployment.yaml
@@ -17,6 +17,9 @@ metadata:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.dataservice.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.dataservice.deployment.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.dataservice.autoscaling.enabled }}
   replicas: {{ .Values.dataservice.deployment.replicas }}
   {{- end }}

--- a/charts/portkey-gateway/templates/gateway/deployment.yaml
+++ b/charts/portkey-gateway/templates/gateway/deployment.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/charts/portkey-gateway/templates/milvus/etcd-statefulset.yaml
+++ b/charts/portkey-gateway/templates/milvus/etcd-statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.milvus.etcd.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.milvus.etcd.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: milvus-etcd
   replicas: 1
   selector:

--- a/charts/portkey-gateway/templates/milvus/milvus-statefulset.yaml
+++ b/charts/portkey-gateway/templates/milvus/milvus-statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.milvus.milvus.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.milvus.milvus.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: milvus
   replicas: 1
   selector:

--- a/charts/portkey-gateway/templates/minio/statefulset.yaml
+++ b/charts/portkey-gateway/templates/minio/statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.minio.statefulSet.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.minio.statefulSet.revisionHistoryLimit }}
+  {{- end }}
   serviceName: minio
   replicas: 1
   selector:

--- a/charts/portkey-gateway/templates/redis/deployment.yaml
+++ b/charts/portkey-gateway/templates/redis/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "redis.labels" . | nindent 4 }}
 spec:
+  {{- if not (kindIs "invalid" .Values.redis.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.redis.revisionHistoryLimit }}
+  {{- end }}
   replicas: 1
   selector:
     matchLabels:

--- a/charts/portkey-gateway/values.yaml
+++ b/charts/portkey-gateway/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+# -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+revisionHistoryLimit: 10
+
 # Deployment strategy configuration
 # Example:
 # strategy:
@@ -372,6 +375,8 @@ dataservice:
   deployment:
     autoRestart: true
     replicas: 1
+    # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     # terminationGracePeriodSeconds: 30
     labels: {}
     selectorLabels: {}
@@ -473,6 +478,8 @@ redis:
   serviceType: NodePort  
   servicePort: 6379
   containerPort: 6379
+  # -- Number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+  revisionHistoryLimit: 10
   resources: {}
 
 # MinIO configuration section
@@ -487,6 +494,8 @@ minio:
     accessKey: ""
     secretKey: ""
   statefulSet:
+    # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+    revisionHistoryLimit: 10
     labels: {}
     annotations: {}
     podSecurityContext: {}
@@ -525,6 +534,8 @@ milvus:
       annotations: {}
     resources: {}
     statefulSet:
+      # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+      revisionHistoryLimit: 10
       labels: {}
       annotations: {}
       podSecurityContext: {}
@@ -546,6 +557,8 @@ milvus:
       annotations: {}
     resources: {}
     statefulSet:
+      # -- Number of old ControllerRevisions to retain to allow rollback. Defaults to 10.
+      revisionHistoryLimit: 10
       labels: {}
       annotations: {}
       podSecurityContext: {}


### PR DESCRIPTION
…rtkey-app and portkey-gateway

Introduced the revisionHistoryLimit parameter across various components to retain old ReplicaSets and ControllerRevisions for rollback purposes. This enhancement improves deployment management and recovery options.